### PR TITLE
Improve performance

### DIFF
--- a/LoopFinder.cpp
+++ b/LoopFinder.cpp
@@ -22,21 +22,17 @@
 
 // Meaningful Parameters by Section
 //
-// 1 ) Initial zero-crossing candidate selection
-//     - N/A
-// 2 ) Subsampling of candidates
-//     - consecutiveCandidates
-//     - rejectWindowMs
-// 3 ) Compute Power Spectra
+// 1 ) Compute Power Spectra
 //     - FFTWindowSize
 //     - FFTWindowType
-// 4 ) Spectral Similarity Calculation
+//     - FFTWindowOverlap
+// 2 ) Spectral Similarity Calculation
 //     - windowComparisonRange
 //     - spectralSimilarityThreshold
-// 5 ) Local Sample Correlation Calculation
-//     - spectralCandidatesToCheck
+// 3 ) Local Sample Correlation Calculation
+//     - spectralWindowsToCheck
 //     - localSampleRange
-// 6 ) Metric Integration
+// 4 ) Metric Integration
 //     - spectralWeight
 //     - sampleWeight
 //     - qualityThreshold
@@ -67,13 +63,14 @@ std::pair<unsigned, unsigned> LoopFinderAlgorithm(
   // FFT
   const unsigned FFTWindowSize = 2048; // 1024 should be good. could try 2048 w overlaps.any bigger would obscure the features we're interested in at high pitches
   const unsigned FFTWindowType = 3; // 3 = Hanning. 3 is great, 4, 6, and 9 look same as 3
+  const unsigned FFTWindowOverlap = FFTWindowSize / 2;
 
   // Spectral Similarity
   const unsigned windowComparisonRange = 8;
   const double spectralSimilarityThreshold = 0.5;
 
   // Local Sample Correlation
-  const unsigned spectralCandidatesToCheck = 6000;
+  const unsigned spectralWindowsToCheck = 50;
   const unsigned localSampleRange = 800;
 
   // Metric Integration
@@ -82,7 +79,9 @@ std::pair<unsigned, unsigned> LoopFinderAlgorithm(
   const double qualityThreshold = 0.85;
 
   // General useful things
-  const unsigned analysisBuffer = std::max(FFTWindowSize * windowComparisonRange, localSampleRange);
+  const unsigned FFTWindowSizeMinusOverlap = FFTWindowSize - FFTWindowOverlap;
+  const unsigned analysisBuffer = std::max(FFTWindowSizeMinusOverlap * windowComparisonRange, localSampleRange);
+  const unsigned analysisBufferWindows = std::max(windowComparisonRange, localSampleRange / FFTWindowSizeMinusOverlap);
   const unsigned earliestLoopablePos = sustainStartPos + analysisBuffer;
   const unsigned latestLoopablePos = sustainEndPos - analysisBuffer;
 
@@ -91,46 +90,19 @@ std::pair<unsigned, unsigned> LoopFinderAlgorithm(
   }
 
   /////////////////////////////////////////////////////////////////////////////
-  //  FINDING CANDIDATES
-  /////////////////////////////////////////////////////////////////////////////
-
-  std::vector<unsigned> zeroCrossings  = findZeroCrossings(lpcmData, earliestLoopablePos, latestLoopablePos);
-
-  if (zeroCrossings.size() < 2) {
-    throw std::invalid_argument("Sustain region must contain at least 2 zero crossings to loop.");
-  }
-
-  // zeroCrossings now contains all zero crossings in the sustain section in ascending order
-
-  /////////////////////////////////////////////////////////////////////////////
-  //  SUBSAMPLE CANDIDATES (for performance)
-  /////////////////////////////////////////////////////////////////////////////
-
-  // Subsample with this algorithm
-  //  1) Keep X consecutive candidates
-  //  2) Then reject all candidates for Y milliseconds afterwards
-  //  - Repeat until all candidates have been sampled
-  // This gives us clusters of points across the audio.
-  // . . . .        . . . .        . . . .        . . . .
-
-  unsigned rejectWindow = sampleRate * rejectWindowMs / 1000;
-  std::vector<unsigned> subsampledZeroCrossings = strideSubsample(zeroCrossings, consecutiveCandidates, rejectWindow);
-
-  zeroCrossings.clear();
-
-  /////////////////////////////////////////////////////////////////////////////
   //  WINDOW AND FFT AUDIO DATA
   /////////////////////////////////////////////////////////////////////////////
 
-  const unsigned numWindows = (sustainEndPos - sustainStartPos - FFTWindowSize) / (FFTWindowSize / 2) + 1;
+  const unsigned numWindows = (sustainEndPos - sustainStartPos) / FFTWindowSizeMinusOverlap - 1;
 
-  // Allocate memory for windows and powerSpectra
+  // Allocate memory for windows, powerSpectra, and spectralCentroids
   double** windows = new double*[numWindows];
   double** powerSpectra = new double*[numWindows];
+  double* spectralCentroids = new double[numWindows];
 
   // Calculate power spectra FFT for each window of audio
   for (unsigned i = 0; i < numWindows; i++) {
-      unsigned windowStartPos = i * (FFTWindowSize / 2) + sustainStartPos;
+      unsigned windowStartPos = i * FFTWindowSizeMinusOverlap + sustainStartPos;
       windows[i] = copyLPCMData(lpcmData, windowStartPos, FFTWindowSize);
 
       // Apply window function to the lpcm window data
@@ -142,69 +114,77 @@ std::pair<unsigned, unsigned> LoopFinderAlgorithm(
 
       // Apply perceptual curving to the PowerSpectra
       curveSpectrum(powerSpectra[i], FFTWindowSize);
+
+      // Compute spectral centroid
+      spectralCentroids[i] = computeSpectralCentroid(powerSpectra[i], sampleRate, FFTWindowSize);
   }
 
   /////////////////////////////////////////////////////////////////////////////
-  //  COMPUTE SPECTRAL SIMILARITY
+  //  FIND SPECTRALLY SIMILAR WINDOWS
   /////////////////////////////////////////////////////////////////////////////
 
   const unsigned numComparisonWindows = windowComparisonRange * 2 + 1;
   const unsigned minLoopDurationSamples = sampleRate * minLoopDurationMs / 1000;
+  const unsigned minLoopDurationWindows = 1 +  (minLoopDurationSamples - 1) / (FFTWindowSizeMinusOverlap);
   const unsigned FFTCenterOffset = FFTWindowSize / 4;
+  const unsigned centroidComparisonRange = 250; // todo: make this a function of spectralsimilaritythreshold. 250 is very very roughly 0.85 normalized RMSE
 
-  std::vector<std::pair<std::pair<unsigned, unsigned>, double > > spectralLoopCandidates;
+  // reduce our comparison pool by grouping windows by spectral centroid in O(n) time
+  std::vector<std::pair<unsigned, unsigned>> loopWindows = determineWindowsToCompare(
+    spectralCentroids,
+    numWindows,
+    analysisBufferWindows,
+    centroidComparisonRange
+  );
 
+  std::vector<std::pair<std::pair<unsigned, unsigned>, double >> spectralLoopCandidates;
+
+  // memoize duplicate spectral similarity calculations
   double* memoizationTable = new double[numWindows * numWindows];
   std::fill_n(memoizationTable, numWindows * numWindows, -1.0);
 
-  // loop over each pair of subsampledZeroCrossings
-  for (unsigned i = 0; i < subsampledZeroCrossings.size() - 1; i++) {
-    unsigned loopStartPos = subsampledZeroCrossings[i];
-    unsigned startWindowIndex = 2 * (loopStartPos - sustainStartPos + FFTCenterOffset) / FFTWindowSize - 1;
+  // Loop over pairs, storing pairs that are within the spectral similarity threshold
+  for (unsigned i = 0; i < loopWindows.size(); i++) {
+    unsigned startWindowIndex = loopWindows[i].first;
+    unsigned endWindowIndex = loopWindows[i].second;
 
-    for (unsigned j = subsampledZeroCrossings.size() - 1; j > i + 1; j--) {
-      unsigned loopEndPos = subsampledZeroCrossings[j];
+    // skip windows that are too close to meet minimum loop length
+    if (endWindowIndex - startWindowIndex < minLoopDurationWindows) {
+      continue;
+    }
 
-      if (loopEndPos - loopStartPos < minLoopDurationSamples) {
-        continue; // skip if the loop is too short
+    // Calculate spectral similarity for windows in comparison range
+    double* spectralResults = new double[numComparisonWindows];
+
+    for (unsigned w = 0; w < numComparisonWindows; w++) {
+      unsigned windowAIndex = startWindowIndex + w - windowComparisonRange;
+      unsigned windowBIndex = endWindowIndex + w - windowComparisonRange;
+
+      // Check if the similarity value is already calculated and stored
+      if (memoizationTable[windowAIndex * numWindows + windowBIndex] != -1.0) {
+        spectralResults[w] = memoizationTable[windowAIndex * numWindows + windowBIndex];
+      } else {
+        spectralResults[w] = RMSE(powerSpectra[windowAIndex], powerSpectra[windowBIndex], FFTWindowSize / 2);
+        memoizationTable[windowAIndex * numWindows + windowBIndex] = spectralResults[w];
       }
+    }
 
-      unsigned endWindowIndex = 2 * (loopEndPos - sustainStartPos + FFTCenterOffset) / FFTWindowSize - 1;
+    // Average and normalize the results
+    double averageRMSE = BartlettWeightedAverage(spectralResults, numComparisonWindows);
+    double normalRMSE = normalizeSpectrumRMSE(averageRMSE);
 
-      // Calculate spectral similarity for windows in comparison range
-      double* spectralResults = new double[numComparisonWindows];
+    delete[] spectralResults;
 
-      for (unsigned w = 0; w < numComparisonWindows; w++) {
-        unsigned windowAIndex = startWindowIndex + w - windowComparisonRange;
-        unsigned windowBIndex = endWindowIndex + w - windowComparisonRange;
-
-        // Check if the similarity value is already calculated and stored
-        if (memoizationTable[windowAIndex * numWindows + windowBIndex] != -1.0) {
-          spectralResults[w] = memoizationTable[windowAIndex * numWindows + windowBIndex];
-        } else {
-          spectralResults[w] = RMSE(powerSpectra[windowAIndex], powerSpectra[windowBIndex], FFTWindowSize / 2);
-          memoizationTable[windowAIndex * numWindows + windowBIndex] = spectralResults[w];
-        }
-      }
-
-      // Average and normalize the results
-      double averageRMSE = BartlettWeightedAverage(spectralResults, numComparisonWindows);
-      double normalRMSE = normalizeSpectrumRMSE(averageRMSE);
-
-      delete[] spectralResults;
-
-      // Add good loops to candidate vector
-      if (normalRMSE >= spectralSimilarityThreshold) {
-        spectralLoopCandidates.push_back(
-          std::make_pair(
-            std::make_pair((loopStartPos), (loopEndPos)),
-            normalRMSE
-          )
-        );
-      }
-
-    } // end candidate loop
-  } // start candidate loop
+    // Add good loops to candidate vector
+    if (normalRMSE >= spectralSimilarityThreshold) {
+      spectralLoopCandidates.push_back(
+        std::make_pair(
+          loopWindows[i],
+          normalRMSE
+        )
+      );
+    }
+  }
 
   // Free memory for windows and powerSpectra, we're done with them
   for (unsigned i = 0; i < numWindows; i++) {
@@ -215,61 +195,89 @@ std::pair<unsigned, unsigned> LoopFinderAlgorithm(
   delete[] windows;
   delete[] powerSpectra;
   delete[] memoizationTable;
-
-  // We're also done with subsampledZeroCrossings
-  subsampledZeroCrossings.clear();
+  delete[] spectralCentroids;
 
   // Now we have a vector spectralLoopCandidates with the structure:
-  // ( (loopStartPos, loopEndPos), spectralSimilarity )
+  // ( (startWindowIndex, endWindowIndex), spectralSimilarity )
 
   if (spectralLoopCandidates.empty()) {
     return nullReturn;
-    throw std::logic_error("No loop candidates meet spectral criteria. Try reducing minLoopDurationMs or spectralSimilarityThreshold.");
+    throw std::logic_error("No regions meet spectral criteria. Try reducing minLoopDurationMs or spectralSimilarityThreshold.");
   }
-
-  std::cout << "There are " << spectralLoopCandidates.size() << " spectralLoopCandidates" << std::endl;
 
   /////////////////////////////////////////////////////////////////////////////
   //  LOCAL SAMPLE CORRELATION
   /////////////////////////////////////////////////////////////////////////////
 
+  unsigned rejectWindow = sampleRate * rejectWindowMs / 1000;
+
   const unsigned localWindowSize = localSampleRange * 2 + 1;
   std::vector<std::pair<std::pair<unsigned, unsigned>, double>> finalLoops;
 
-  // loop over top X loops, perform sample-per-sample correlation, integrate the results
-  keepBestLoops(spectralLoopCandidates, spectralCandidatesToCheck); // filter for best candidates
+  // loop over top X window pairs, perform sample-per-sample correlation, integrate the results
+  keepBestLoops(spectralLoopCandidates, spectralWindowsToCheck); // filter for best candidates
 
   for (unsigned i = 0; i < spectralLoopCandidates.size(); i++) {
-    unsigned loopStartPos = spectralLoopCandidates[i].first.first;
-    unsigned loopEndPos = spectralLoopCandidates[i].first.second;
-
-    // Compute mean absolute difference of the start and end windows
-    double* startPointSampleWindow = copyLPCMData(lpcmData, loopStartPos - localSampleRange, localWindowSize);
-    double* endPointSampleWindow = copyLPCMData(lpcmData, loopEndPos - localSampleRange, localWindowSize);
-    WindowFunc(2, localWindowSize, startPointSampleWindow); // 1, 2, or 6 work well
-    WindowFunc(2, localWindowSize, endPointSampleWindow);
-
-    double mad = MeanAbsoluteDifference(startPointSampleWindow, endPointSampleWindow, localWindowSize);
-    double sampleSimilarity = normalizeSampleWindowMAD(mad);
-
-    delete[] startPointSampleWindow;
-    delete[] endPointSampleWindow;
-
-    // Integrate the spectral and sample results
+    unsigned startWindowIndex = spectralLoopCandidates[i].first.first;
+    unsigned endWindowIndex = spectralLoopCandidates[i].first.second;
     double spectralSimilarity = spectralLoopCandidates[i].second;
-    double integratedQuality = (spectralWeight * spectralSimilarity + sampleWeight * sampleSimilarity) / (spectralWeight + sampleWeight);
 
-    // Add good loops to final vector
-    if (integratedQuality >= qualityThreshold) {
-      finalLoops.push_back(
-        std::make_pair(
-          std::make_pair(
-            (loopStartPos),
-            (loopEndPos)
-          ),
-          integratedQuality
-        )
-      );
+    unsigned startWindowStartPos = (startWindowIndex + 1) * FFTWindowSizeMinusOverlap + sustainStartPos - FFTCenterOffset;
+    unsigned startWindowEndPos = startWindowStartPos + FFTWindowSizeMinusOverlap - 1;
+
+    unsigned endWindowStartPos = (endWindowIndex + 1) * FFTWindowSizeMinusOverlap + sustainStartPos - FFTCenterOffset;
+    unsigned endWindowEndPos = endWindowStartPos + FFTWindowSizeMinusOverlap - 1;
+
+    //unsigned startWindowCenterPos = FFTWindowSizeMinusOverlap * (startWindowIndex + 1) + sustainStartPos;
+    //unsigned endWindowCenterPos = FFTWindowSizeMinusOverlap * (endWindowIndex + 1) + sustainStartPos;
+
+    // Get zero crossings for local window analysis
+    std::vector<unsigned> startZeroCrossings = findZeroCrossings(lpcmData, startWindowStartPos, startWindowEndPos);
+    std::vector<unsigned> endZeroCrossings  = findZeroCrossings(lpcmData, endWindowStartPos, endWindowEndPos); // todo - it would be better to center this on the window
+
+    // subsample the zero crossings to reduce the number of comparisons
+    std::vector<unsigned> subsampledStartZeroCrossings = strideSubsample(startZeroCrossings, 1, FFTWindowSizeMinusOverlap / 3); // spread out across window
+    std::vector<unsigned> subsampledEndZeroCrossings = strideSubsample(endZeroCrossings, consecutiveCandidates, rejectWindow); // clustered
+
+    // iterate over each pair of zero crossings, and find the best match
+    for (unsigned j = 0; j < subsampledStartZeroCrossings.size(); j++) {
+      unsigned startZeroCrossing = startZeroCrossings[j];
+      double* startPointSampleWindow = copyLPCMData(lpcmData, startZeroCrossing - localSampleRange, localWindowSize);
+      WindowFunc(2, localWindowSize, startPointSampleWindow); // 1, 2, or 6 work well
+      for (unsigned k = 0; k < subsampledEndZeroCrossings.size(); k++) {
+        unsigned endZeroCrossing = endZeroCrossings[k];
+
+        // skip if the loop is too short
+        if (endZeroCrossing - startZeroCrossing < minLoopDurationSamples) {
+          continue;
+        }
+
+        // Compute mean absolute difference of the start and end windows
+        double* endPointSampleWindow = copyLPCMData(lpcmData, endZeroCrossing - localSampleRange, localWindowSize);
+        WindowFunc(2, localWindowSize, endPointSampleWindow);
+
+        double mad = MeanAbsoluteDifference(startPointSampleWindow, endPointSampleWindow, localWindowSize);
+        double sampleSimilarity = normalizeSampleWindowMAD(mad);
+        delete[] endPointSampleWindow;
+
+        // Integrate the spectral and sample results
+        double integratedQuality = (spectralWeight * spectralSimilarity + sampleWeight * sampleSimilarity) / (spectralWeight + sampleWeight);
+
+        // Add good loops to final vector
+        if (integratedQuality >= qualityThreshold) {
+          finalLoops.push_back(
+            std::make_pair(
+              std::make_pair(
+                startZeroCrossing,
+                endZeroCrossing
+              ),
+              integratedQuality
+            )
+          );
+        }
+      }
+
+      delete[] startPointSampleWindow;
     }
   }
 

--- a/utils/AudioUtils.cpp
+++ b/utils/AudioUtils.cpp
@@ -67,3 +67,18 @@ double normalizeSampleWindowMAD(double x) {
 
     return x;
 }
+
+double computeSpectralCentroid(const double* powerSpectrum, unsigned sampleRate, unsigned windowSize) {
+    double totalPower = 0.0;
+    double weightedSum = 0.0;
+
+    // Calculate weighted sum of frequencies and total power
+    for (size_t i = 0; i < windowSize / 2; ++i) {
+        double frequency = static_cast<double>(i) * sampleRate / windowSize;
+        weightedSum += frequency * powerSpectrum[i];
+        totalPower += powerSpectrum[i];
+    }
+
+    // Calculate spectral centroid
+    return weightedSum / totalPower;
+}

--- a/utils/AudioUtils.h
+++ b/utils/AudioUtils.h
@@ -23,4 +23,6 @@ double normalizeSpectrumJSDivergence(double x);
 
 double normalizeSampleWindowMAD(double x);
 
+double computeSpectralCentroid(const double* powerSpectrum, unsigned sampleRate, unsigned windowSize);
+
 #endif // AUDIOUTILS_H

--- a/utils/Utils.h
+++ b/utils/Utils.h
@@ -11,10 +11,13 @@
 
 #include <algorithm>
 #include <queue>
+#include <unordered_map>
 #include <vector>
 
 std::vector<unsigned> strideSubsample(const std::vector<unsigned>& v, const unsigned consecutiveElements, const unsigned rejectWindow);
 
 void keepBestLoops(std::vector<std::pair<std::pair<unsigned int, unsigned int>, double>>& loops, unsigned keep);
+
+std::vector<std::pair<unsigned, unsigned>> determineWindowsToCompare(double* spectralCentroids, unsigned numWindows, unsigned analysisBufferWindows, unsigned centroidComparisonRange);
 
 #endif // UTILS_H


### PR DESCRIPTION
This PR significantly improves performance by restructuring the algorithm.

- Power spectra are now compared at a window level instead of a zero-crossing level. This eliminates a huge number of duplicate comparisons
- Power spectra are grouped ("hashed") by spectral centroid. Only spectra within a group are compared. This reduces the O(n^2) comparisons to identify similar windows
- Zero-crossing detection and subsampling is only done for the windows identified as spectral candidates.
- Zero crossing subsampling now works by selecting 3 crossing candidates (spread across the FFT window length) for the start window and 15 consecutive candidates for the end window. This seems to return better results with fewer comparisons overall.

Testing on my laptop, this new algorithm took 600-800ms per sample, compared to 2-3 sec. per sample with the old algorithm.